### PR TITLE
Minor cleanup

### DIFF
--- a/src/Cat.agda
+++ b/src/Cat.agda
@@ -8,13 +8,13 @@ record Cat : Type (lsuc (l ⊔ m ⊔ n)) where
   field _~>_ : Obj -> Obj -> Type m
   infix 1 _~>_
 
-  field _≈_ : ∀ {a1 a2 : Obj} -> (a1 ~> a2) -> (a1 ~> a2) -> Type n
+  field _≈_ : ∀ {a1 a2} -> (a1 ~> a2) -> (a1 ~> a2) -> Type n
   infix 1 _≈_
 
-  field ι₂ : ∀ {a1 a2 : Obj} {f : a1 ~> a2} -> (f ≈ f)
-  field ÷₂_ : ∀ {a1 a2 : Obj} {f1 f2 : a1 ~> a2} -> (f1 ≈ f2) -> (f2 ≈ f1)
+  field ι₂ : ∀ {a1 a2} {f : a1 ~> a2} -> (f ≈ f)
+  field ÷₂_ : ∀ {a1 a2} {f1 f2 : a1 ~> a2} -> (f1 ≈ f2) -> (f2 ≈ f1)
   infix 12 ÷₂_
-  field _⨾₂_ : ∀ {a1 a2 : Obj} {f1 f2 f3 : a1 ~> a2} -> (f1 ≈ f2) -> (f2 ≈ f3) -> (f1 ≈ f3)
+  field _⨾₂_ : ∀ {a1 a2} {f1 f2 f3 : a1 ~> a2} -> (f1 ≈ f2) -> (f2 ≈ f3) -> (f1 ≈ f3)
   infixl 9 _⨾₂_
 
   field ι : ∀ {a} -> (a ~> a)
@@ -22,14 +22,15 @@ record Cat : Type (lsuc (l ⊔ m ⊔ n)) where
 
   field _⨾_ : ∀ {a1 a2 a3} -> (a1 ~> a2) -> (a2 ~> a3) -> (a1 ~> a3)
   infixl 9 _⨾_
-  field _⨾′_ : ∀ {a1 a2 a3} -> ∀ {f1 f2 : a1 ~> a2} -> (f1 ≈ f2) -> ∀ {g1 g2 : a2 ~> a3} -> (g1 ≈ g2) -> ((f1 ⨾ g1) ≈ (f2 ⨾ g2))
+  field
+    _⨾′_ : ∀ {a1 a2 a3} -> {f1 f2 : a1 ~> a2} -> (f1 ≈ f2) -> {g1 g2 : a2 ~> a3} -> (g1 ≈ g2) -> ((f1 ⨾ g1) ≈ (f2 ⨾ g2))
   infixl 9 _⨾′_
 
-  _^⨾′_ : ∀ {a1 a2 a3} -> (f : a1 ~> a2) -> ∀ {g1 g2 : a2 ~> a3} -> (g1 ≈ g2) -> ((f ⨾ g1) ≈ (f ⨾ g2))
+  _^⨾′_ : ∀ {a1 a2 a3} -> (f : a1 ~> a2) -> {g1 g2 : a2 ~> a3} -> (g1 ≈ g2) -> ((f ⨾ g1) ≈ (f ⨾ g2))
   f ^⨾′ q = ι₂ ⨾′ q
   infixr 9 _^⨾′_
 
-  _⨾′^_ : ∀ {a1 a2 a3} -> ∀ {f1 f2 : a1 ~> a2} -> (f1 ≈ f2) -> (g : a2 ~> a3) -> ((f1 ⨾ g) ≈ (f2 ⨾ g))
+  _⨾′^_ : ∀ {a1 a2 a3} -> {f1 f2 : a1 ~> a2} -> (f1 ≈ f2) -> (g : a2 ~> a3) -> ((f1 ⨾ g) ≈ (f2 ⨾ g))
   p ⨾′^ g = p ⨾′ ι₂
   infixl 9 _⨾′^_
 

--- a/src/Functor.agda
+++ b/src/Functor.agda
@@ -7,9 +7,9 @@ record Functor (A B : Cat) : Type (l ⊔ m ⊔ n) where
   private module A = Cat A
   private module B = Cat B
   field run : A.Obj -> B.Obj
-  field map : ∀ {a1 a2 : A.Obj} -> a1 A.~> a2 -> run a1 B.~> run a2
+  field map : ∀ {a1 a2} -> a1 A.~> a2 -> run a1 B.~> run a2
 
-  field mapι : ∀ {a : A.Obj} -> map (A.ι {a}) B.≈ B.ι {run a}
+  field mapι : ∀ {a} -> map (A.ι {a}) B.≈ B.ι {run a}
   field map⨾ : ∀ {a1 a2 a3} {f1 : a1 A.~> a2} {f2 : a2 A.~> a3} -> (map f1 B.⨾ map f2) B.≈ map (f1 A.⨾ f2)
 
   field map′ : ∀ {a1 a2} {f1 f2 : a1 A.~> a2} -> (f1 A.≈ f2) -> (map f1) B.≈ (map f2)

--- a/src/Functor.agda
+++ b/src/Functor.agda
@@ -9,7 +9,7 @@ record Functor (A B : Cat) : Type (l ⊔ m ⊔ n) where
   field run : A.Obj -> B.Obj
   field map : ∀ {a1 a2} -> a1 A.~> a2 -> run a1 B.~> run a2
 
-  field mapι : ∀ {a} -> map (A.ι {a}) B.≈ B.ι {run a}
+  field mapι : ∀ {a} -> B.ι {run a} B.≈ map (A.ι {a})
   field map⨾ : ∀ {a1 a2 a3} {f1 : a1 A.~> a2} {f2 : a2 A.~> a3} -> (map f1 B.⨾ map f2) B.≈ map (f1 A.⨾ f2)
 
   field map′ : ∀ {a1 a2} {f1 f2 : a1 A.~> a2} -> (f1 A.≈ f2) -> (map f1) B.≈ (map f2)

--- a/src/Presheaf.agda
+++ b/src/Presheaf.agda
@@ -5,16 +5,21 @@ open import Set.Cat sl sm
 
 record Presheaf (A : Cat) : Type (lsuc (sl ⊔ sm) ⊔ l ⊔ m ⊔ n) where
   private module A = Cat A
+
   field Run : A.Obj -> Set.Obj
   module Run a = Set.Obj (Run a)
   private module Run-implicit {a} = Run a
-  field Map : ∀ {a1 a2 : A.Obj} -> (a2 A.~> a1) -> (Run a1 Set.~> Run a2)
+
+  field Map : ∀ {a1 a2} -> (a2 A.~> a1) -> (Run a1 Set.~> Run a2)
   module Map {a1} {a2} f = Set._~>_ (Map {a1} {a2} f)
-  field Map′ : ∀ {a1 a2 : A.Obj} {f1 f2 : a2 A.~> a1} -> (f1 A.≈ f2) -> Map f1 Set.≈ Map f2
+
+  field Map′ : ∀ {a1 a2} {f1 f2 : a2 A.~> a1} -> (f1 A.≈ f2) -> Map f1 Set.≈ Map f2
   module Map′ {a1} {a2} {f1} {f2} f12 = Set._≈_ (Map′ {a1} {a2} {f1} {f2} f12)
-  field Map-ι : ∀ {a : A.Obj} -> Map (A.ι {a}) Set.≈ Set.ι {Run a}
+
+  field Map-ι : ∀ {a} -> Set.ι {Run a} Set.≈ Map (A.ι {a})
   module Map-ι {a} = Set._≈_ (Map-ι {a})
-  field Map-⨾ : ∀ {a1 a2 a3 : A.Obj} (f : a1 A.~> a2) (g : a2 A.~> a3) -> (Map g Set.⨾ Map f) Set.≈ Map (f A.⨾ g)
+
+  field Map-⨾ : ∀ {a1 a2 a3} (f : a1 A.~> a2) (g : a2 A.~> a3) -> (Map g Set.⨾ Map f) Set.≈ Map (f A.⨾ g)
   module Map-⨾ {a1} {a2} {a3} f g = Set._≈_ (Map-⨾ {a1} {a2} {a3} f g)
 
   open Run-implicit public using ()

--- a/src/Presheaf/Hom.agda
+++ b/src/Presheaf/Hom.agda
@@ -13,7 +13,7 @@ open C
   { Run = λ{ a1 -> record { Obj = a1 ~> a2 ; _~_ = _≈_ ; ι = ι₂ ; ÷_ = ÷₂_ ; _⨾_ = _⨾₂_ } }
   ; Map = λ f → record { run = f ⨾_ ; map = f ^⨾′_ }
   ; Map′ = λ e → record { component = e ⨾′^_ }
-  ; Map-ι = record { component = λ{ a -> ι⨾ } }
+  ; Map-ι = record { component = λ{ _ -> ÷₂ ι⨾ } }
   ; Map-⨾ = λ{ f g -> record { component = λ{ a -> ⨾⨾ } } }
   }
 infix 9 ∙~>_


### PR DESCRIPTION
- Flip map-id laws for consistency with map-compose (and to match lax monoidal functors where it actually matters)
- Avoid using both ∀ and a type signature
- 120 char line limit